### PR TITLE
Added 'urldecode' to the value in Sha1Composer (following the documentation)

### DIFF
--- a/src/LinkORB/Buckaroo/SignatureComposer/Sha1Composer.php
+++ b/src/LinkORB/Buckaroo/SignatureComposer/Sha1Composer.php
@@ -38,7 +38,7 @@ class Sha1Composer implements SignatureComposer
         $signatureString = '';
 
         foreach ($parameters as $key => $value) {
-            $signatureString .= $key . '=' . $value;
+            $signatureString .= $key . '=' . urldecode($value);
         }
 
         $signatureString .= $this->secret;


### PR DESCRIPTION
Documentation:
> **Please note:** _When verifying a received signature. first url-decode all the field values. A signature is always calculated over the non-encoded values (i.e. The value "J.+de+Tester" should be decoded to "J. de Tester")_.